### PR TITLE
Add mainnet transaction support and test TX4

### DIFF
--- a/spendProof/scripts/generate_witness.js
+++ b/spendProof/scripts/generate_witness.js
@@ -22,13 +22,13 @@ function decodeMoneroAddress(address) {
 
 // Real Monero stagenet transaction data
 const TX_DATA = {
-    hash: "5caae835b751a5ab243b455ad05c489cb9a06d8444ab2e8d3a9d8ef905c1439a",
-    block: 1934116,
-    secretKey: "4cbf8f2cfb622ee126f08df053e99b96aa2e8c1cfd575d2a651f3343b465800a",
-    amount: 20000000000,
-    destination: "53Kajgo3GhV1ddabJZqdmESkXXoz2xD2gUCVc5L2YKjq8Qhx6UXoqFChhF9n2Th9NLTz77258PMdc3G5qxVd487pFZzzVNG",
+    hash: "bb1eab8e0de071a272e522ad912d143aa531e0016d51e0aec800be39511dd141",
+    block: 3569096,
+    secretKey: "9be32769af6e99d0fef1dcddbef68f254004e2eb06e8f712c01a63d235a5410c",
+    amount: 931064529072,
+    destination: "87DZ8wkCoePVH7UH7zL3FhR2CjadnC83pBMqXZizg7T2dJod5rzQuAMbBg5PtcA9dHTtWAvrL7ZCTXEC2RDV3Mr4HJYP9gj",
     output_index: 0,
-    node: "https://stagenet.xmr.ditatompel.com"
+    node: "https://monero-rpc.cheems.de.box.skhron.com.ua:18089"
 };
 
 async function generateWitness() {
@@ -38,7 +38,7 @@ async function generateWitness() {
     
     try {
         // Step 1: Fetch transaction data
-        console.log("📡 Step 1: Fetching transaction from stagenet...");
+        console.log("📡 Step 1: Fetching transaction from node...");
         const response = await axios.post(`${TX_DATA.node}/gettransactions`, {
             txs_hashes: [TX_DATA.hash],
             decode_as_json: true

--- a/spendProof/scripts/test_all_txs.js
+++ b/spendProof/scripts/test_all_txs.js
@@ -9,7 +9,8 @@ const transactions = [
         secretKey: "4cbf8f2cfb622ee126f08df053e99b96aa2e8c1cfd575d2a651f3343b465800a",
         amount: 20000000000,
         destination: "53Kajgo3GhV1ddabJZqdmESkXXoz2xD2gUCVc5L2YKjq8Qhx6UXoqFChhF9n2Th9NLTz77258PMdc3G5qxVd487pFZzzVNG",
-        output_index: 0  // Confirmed by block explorer: output 0 matches with 0.02 XMR
+        output_index: 0,  // Confirmed by block explorer: output 0 matches with 0.02 XMR
+        node: "https://stagenet.xmr.ditatompel.com"
     },
     {
         name: "TX2",
@@ -17,7 +18,8 @@ const transactions = [
         block: 1948001,
         secretKey: "c7637fdfa0ae785a8982473b49a6c1ebf082e6737b837f4e1c40a270acf8130e",
         amount: 0.010000000000,
-        destination: "74Di3cYaTj7DG5D7ucHEeiSZzrH9kyrFX8ujg2S3ydoZQEkKhpFjGkGLcpenYEHMW1aYNQcy6n75MbDfFwch4657E8WjVhE"
+        destination: "74Di3cYaTj7DG5D7ucHEeiSZzrH9kyrFX8ujg2S3ydoZQEkKhpFjGkGLcpenYEHMW1aYNQcy6n75MbDfFwch4657E8WjVhE",
+        node: "https://stagenet.xmr.ditatompel.com"
     },
     {
         name: "TX3",
@@ -26,11 +28,22 @@ const transactions = [
         secretKey: "ab923eb60a5de7ff9e40be288ae55ccaea5a6ee175180eabe7774a2951d59701",
         amount: 0.001150000000,
         destination: "77tyMuyZhpUNuqKfNTHL3J9AxDVX6MKRvgjLEMPra23CMUGX1UZEHJYLtG54ziVsUqdDLbtLrpMCnbPgvqAAzJrRM3jevta",
-        output_index: 0
+        output_index: 0,
+        node: "https://stagenet.xmr.ditatompel.com"
+    },
+    {
+        name: "TX4 (MAINNET)",
+        hash: "bb1eab8e0de071a272e522ad912d143aa531e0016d51e0aec800be39511dd141",
+        block: 3569096,
+        secretKey: "9be32769af6e99d0fef1dcddbef68f254004e2eb06e8f712c01a63d235a5410c",
+        amount: 0.931064529072,
+        destination: "87DZ8wkCoePVH7UH7zL3FhR2CjadnC83pBMqXZizg7T2dJod5rzQuAMbBg5PtcA9dHTtWAvrL7ZCTXEC2RDV3Mr4HJYP9gj",
+        output_index: 0,
+        node: "https://monero-rpc.cheems.de.box.skhron.com.ua:18089"
     }
 ];
 
-console.log('🧪 Testing all three transactions\n');
+console.log('🧪 Testing all four transactions (3 stagenet + 1 mainnet)\n');
 
 for (const tx of transactions) {
     console.log(`Testing ${tx.name}...`);
@@ -50,7 +63,7 @@ for (const tx of transactions) {
     amount: ${amountPiconero},
     destination: "${tx.destination}",
     output_index: ${tx.output_index || 0},
-    node: "https://stagenet.xmr.ditatompel.com"
+    node: "${tx.node || 'https://stagenet.xmr.ditatompel.com'}"
 };`
     );
     fs.writeFileSync('scripts/generate_witness.js', updated);


### PR DESCRIPTION
- Add TX4: Real mainnet transaction (0.931 XMR) from block 3569096
- Rename test_all_three_txs.js to test_all_txs.js (now tests 4 transactions)
- Add configurable node URL per transaction (stagenet/mainnet)
- Update witness generator to be network-agnostic
- All 4 transactions (3 stagenet + 1 mainnet) pass successfully