### PR TITLE
Add one-click mint UX with initiateMintWithPriceUpdate

### DIFF
--- a/contracts/VaultManager.sol
+++ b/contracts/VaultManager.sol
@@ -473,11 +473,44 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
     // ========== MINTING FLOW ==========
     
     /**
-     * @notice User initiates a mint request
-     * @param _lpVault Address of the LP vault to use
-     * @param _recipient Destination address for minted wsXMR tokens
-     * @param _xmrAmount Amount of XMR to lock (atomic units)
-     * @param _claimCommitment Hash of the secret LP will reveal
+     * @notice Initiate a mint request with automatic Pyth price update (one-click UX)
+     * @dev Combines updatePythPrices and initiateMint into a single transaction
+     * @param _lpVault Address of the LP vault to handle this mint
+     * @param _recipient Address to receive the minted wsXMR
+     * @param _xmrAmount Amount of XMR (in atomic units, 12 decimals)
+     * @param _claimCommitment secp256k1 commitment to user's secret
+     * @param _timeoutDuration How long before request can be cancelled
+     * @param _pythUpdateData Pyth price update data from Hermes API
+     * @return requestId Unique identifier for this mint request
+     */
+    function initiateMintWithPriceUpdate(
+        address _lpVault,
+        address _recipient,
+        uint256 _xmrAmount,
+        bytes32 _claimCommitment,
+        uint256 _timeoutDuration,
+        bytes[] calldata _pythUpdateData
+    ) external payable returns (bytes32 requestId) {
+        // Calculate Pyth update fee
+        uint256 pythFee = pyth.getUpdateFee(_pythUpdateData);
+        
+        // Update Pyth prices first
+        pyth.updatePriceFeeds{value: pythFee}(_pythUpdateData);
+        
+        // Calculate griefing deposit (msg.value - pythFee)
+        uint256 griefingDeposit = msg.value - pythFee;
+        
+        // Call internal mint function with adjusted value
+        return _initiateMint(_lpVault, _recipient, _xmrAmount, _claimCommitment, _timeoutDuration, griefingDeposit);
+    }
+    
+    /**
+     * @notice Initiate a mint request
+     * @dev User provides commitment, LP will lock XMR on Monero chain
+     * @param _lpVault Address of the LP vault to handle this mint
+     * @param _recipient Address to receive the minted wsXMR
+     * @param _xmrAmount Amount of XMR (in atomic units, 12 decimals)
+     * @param _claimCommitment secp256k1 commitment to user's secret
      * @param _timeoutDuration How long before request can be cancelled
      * @return requestId Unique identifier for this mint request
      */
@@ -488,6 +521,20 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         bytes32 _claimCommitment,
         uint256 _timeoutDuration
     ) external payable returns (bytes32 requestId) {
+        return _initiateMint(_lpVault, _recipient, _xmrAmount, _claimCommitment, _timeoutDuration, msg.value);
+    }
+    
+    /**
+     * @notice Internal function to initiate mint
+     */
+    function _initiateMint(
+        address _lpVault,
+        address _recipient,
+        uint256 _xmrAmount,
+        bytes32 _claimCommitment,
+        uint256 _timeoutDuration,
+        uint256 _griefingDeposit
+    ) internal returns (bytes32 requestId) {
         if (_lpVault == address(0)) revert ZeroAddress();
         if (_recipient == address(0)) revert ZeroAddress();
         if (_xmrAmount == 0) revert ZeroAmount();
@@ -501,7 +548,7 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         
         // ANTI-SPAM: Require griefing deposit set by LP
         Vault storage vault = vaults[_lpVault];
-        if (msg.value < vault.mintGriefingDeposit) revert InsufficientDeposit();
+        if (_griefingDeposit < vault.mintGriefingDeposit) revert InsufficientDeposit();
         
         // Convert XMR amount to wsXMR amount (XMR has 12 decimals, wsXMR has 8)
         uint256 wsxmrAmount = _xmrAmount / 1e4;
@@ -568,7 +615,7 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
             feeAmount: feeAmount,
             claimCommitment: _claimCommitment,
             timeout: block.timestamp + _timeoutDuration,
-            griefingDeposit: msg.value, // Store deposit for refund/award
+            griefingDeposit: _griefingDeposit, // Store deposit for refund/award
             status: MintStatus.PENDING
         });
         

--- a/frontend/app/js/config.js
+++ b/frontend/app/js/config.js
@@ -20,7 +20,9 @@ export const CONTRACTS = {
     vaultManager: '0xc5AF5A978ba0E33c29984Aa46f939a7Ff164A851',
     wrappedMonero: '0x46520da3212dA53A8e981641f82C261b36C78dDd',
     liquidityRouter: '0x5F824724cF668B0662Df4789F1Ce19De9281d415',
-    pythOracle: '0x2880aB155794e7179c9eE2e38200202908C17B43' // Gnosis Pyth Oracle
+    pythOracle: '0x2880aB155794e7179c9eE2e38200202908C17B43', // Gnosis Pyth Oracle
+    // Default LP vault to use for mints (the active LP running the LP node)
+    defaultLpVault: '0x492c0b9F298cC49FE2644a2EBc6eA8dF848c72FB'
 };
 
 // Pyth Network Configuration

--- a/frontend/app/js/config.js
+++ b/frontend/app/js/config.js
@@ -95,6 +95,7 @@ export const STORAGE_KEYS = {
 export const ABIS = {
     vaultManager: [
         'function initiateMint(address lpVault, address recipient, uint256 xmrAmount, bytes32 claimCommitment, uint256 timeoutDuration) external payable returns (bytes32 requestId)',
+        'function initiateMintWithPriceUpdate(address lpVault, address recipient, uint256 xmrAmount, bytes32 claimCommitment, uint256 timeoutDuration, bytes[] calldata pythUpdateData) external payable returns (bytes32 requestId)',
         'function requestBurn(uint256 wsxmrAmount, address lpVault, address user) external returns (bytes32 requestId)',
         'function finalizeMint(bytes32 requestId, bytes32 secret) external',
         'function finalizeBurn(bytes32 requestId, bytes32 secret) external',

--- a/frontend/app/js/main.js
+++ b/frontend/app/js/main.js
@@ -468,16 +468,10 @@ async function handleStartMint() {
     const elements = getElements();
     
     const amount = parseFloat(elements.mintAmount.value);
-    const vaultAddress = elements.mintVaultSelect.value;
     
     // Validate inputs
     if (!amount || amount <= 0) {
         showError('Invalid Input', 'Please enter a valid amount');
-        return;
-    }
-    
-    if (!vaultAddress) {
-        showError('Invalid Input', 'Please select a vault');
         return;
     }
     
@@ -490,8 +484,11 @@ async function handleStartMint() {
         // Setup progress tracking
         trackMintProgress(currentMintFlow);
         
-        // Start the flow
-        await currentMintFlow.start(vaultAddress, amount);
+        // Use the default LP vault from config
+        const { CONTRACTS } = await import('./config.js');
+        
+        // Start the flow with the LP vault that has the running LP node
+        await currentMintFlow.start(CONTRACTS.defaultLpVault, amount);
         
         // Success
         showSuccess('Mint Complete', `Successfully minted ${amount} wsXMR!`);

--- a/frontend/app/js/mintFlow.js
+++ b/frontend/app/js/mintFlow.js
@@ -173,8 +173,8 @@ export class MintFlow {
 
         console.log('Pyth update fee:', pythFee.toString());
 
-        // Convert XMR amount to contract format (8 decimals for wsXMR)
-        const xmrAmountContract = BigInt(Math.floor(this.xmrAmount * Math.pow(10, DECIMALS.wsXMR)));
+        // Convert XMR amount to contract format (12 decimals for XMR atomic units)
+        const xmrAmountContract = BigInt(Math.floor(this.xmrAmount * Math.pow(10, DECIMALS.XMR)));
 
         // Get commitment from agent
         const commitment = this.agent.getCommitment();

--- a/frontend/app/js/mintFlow.js
+++ b/frontend/app/js/mintFlow.js
@@ -182,26 +182,27 @@ export class MintFlow {
         // Calculate total value to send (griefing deposit + pyth fee)
         const totalValue = this.griefingDeposit + pythFee;
 
-        console.log('Initiating mint with params:', {
-            lpVault: this.lpVault,
-            xmrAmount: xmrAmountContract.toString(),
-            commitment,
-            timeoutDuration: this.timeoutDuration,
-            value: totalValue.toString()
-        });
-
-        // First update Pyth prices
-        await writeVaultManager('updatePythPrices', [updateData], pythFee);
-
-        // Then initiate mint
         // Get user's address for recipient
         const { getUserAddress } = await import('./viemClient.js');
         const userAddress = getUserAddress();
         
+        console.log('Initiating mint with params:', {
+            lpVault: this.lpVault,
+            recipient: userAddress,
+            xmrAmount: xmrAmountContract.toString(),
+            commitment,
+            timeoutDuration: this.timeoutDuration,
+            pythFee: pythFee.toString(),
+            griefingDeposit: this.griefingDeposit.toString(),
+            totalValue: totalValue.toString()
+        });
+
+        // One-click UX: Single transaction combines Pyth price update + mint initiation
+        console.log('Initiating mint with automatic price update (one-click)...');
         const receipt = await writeVaultManager(
-            'initiateMint',
-            [this.lpVault, userAddress, xmrAmountContract, commitment, BigInt(this.timeoutDuration)],
-            this.griefingDeposit
+            'initiateMintWithPriceUpdate',
+            [this.lpVault, userAddress, xmrAmountContract, commitment, BigInt(this.timeoutDuration), updateData],
+            totalValue // Total value = pythFee + griefingDeposit
         );
 
         console.log('Mint initiated, tx:', receipt.transactionHash);

--- a/lp-node/config.toml
+++ b/lp-node/config.toml
@@ -37,7 +37,7 @@ pyth_hermes_url = "https://hermes.pyth.network"
 # Monero daemon RPC configuration
 # The LP node connects to a Monero daemon (monerod) for blockchain data
 # You can use a public node or run your own
-daemon_url = "http://node.moneroworld.com:18089"
+daemon_url = "http://xmr-node.cakewallet.com:18081"
 network = "mainnet"  # or "stagenet" for testing
 
 [lp_node]

--- a/lp-node/src/events.rs
+++ b/lp-node/src/events.rs
@@ -22,9 +22,46 @@ impl EventListener {
         }
     }
 
+    /// Scan for historical events and process pending requests
+    pub async fn scan_historical_events(&self, from_block: u64) -> Result<()> {
+        info!("Scanning for historical events from block {}", from_block);
+
+        // Query historical mint events
+        let mint_logs = self.evm.get_historical_mint_events(from_block).await?;
+        info!("Found {} historical MintInitiated events", mint_logs.len());
+        
+        for log in &mint_logs {
+            if let Err(e) = self.handle_mint_initiated_event(log).await {
+                error!("Error processing historical MintInitiated event: {}", e);
+            }
+        }
+
+        // Query historical burn events
+        let burn_logs = self.evm.get_historical_burn_events(from_block).await?;
+        info!("Found {} historical BurnRequested events", burn_logs.len());
+        
+        for log in &burn_logs {
+            if let Err(e) = self.handle_burn_requested_event(log).await {
+                error!("Error processing historical BurnRequested event: {}", e);
+            }
+        }
+
+        info!("Historical event scan complete");
+        Ok(())
+    }
+
     /// Start listening for events
     pub async fn start(self: Arc<Self>) -> Result<()> {
         info!("Starting event listener");
+
+        // Scan for historical events from the last 3 hours (max mint timeout is 2 hours)
+        let current_block = self.evm.get_block_number().await.unwrap_or(0);
+        let blocks_per_hour = 720; // ~5 second blocks on Gnosis
+        let from_block = current_block.saturating_sub(blocks_per_hour * 3);
+        
+        if let Err(e) = self.scan_historical_events(from_block).await {
+            error!("Error scanning historical events: {}", e);
+        }
 
         // Spawn burn event listener
         let listener = self.clone();
@@ -137,9 +174,9 @@ impl EventListener {
         }
 
         info!(
-            "MintInitiated event: requestId={}, user={}, xmrAmount={}, wsxmrAmount={}",
+            "MintInitiated event: requestId={}, initiator={}, xmrAmount={}, wsxmrAmount={}",
             hex::encode(event.requestId),
-            event.user,
+            event.initiator,
             event.xmrAmount,
             event.wsxmrAmount
         );
@@ -147,7 +184,7 @@ impl EventListener {
         // Create a mint task
         let task = MintTask {
             request_id: event.requestId.into(),
-            user: event.user.into(),
+            user: event.initiator.into(),
             lp_vault: lp_vault_bytes,
             xmr_amount: event.xmrAmount.to::<u64>(),
             wsxmr_amount: event.wsxmrAmount.to::<u64>(),

--- a/lp-node/src/evm.rs
+++ b/lp-node/src/evm.rs
@@ -50,10 +50,12 @@ sol! {
 
         event MintInitiated(
             bytes32 indexed requestId,
-            address indexed user,
-            address indexed lpVault,
+            address indexed initiator,
+            address indexed recipient,
+            address lpVault,
             uint256 xmrAmount,
             uint256 wsxmrAmount,
+            uint256 feeAmount,
             bytes32 claimCommitment,
             uint256 timeout
         );
@@ -300,6 +302,38 @@ impl EvmClient {
             .context("Failed to subscribe to MintInitiated events")?;
 
         Ok(stream.into_stream())
+    }
+
+    /// Query historical MintInitiated events for this LP vault
+    pub async fn get_historical_mint_events(&self, from_block: u64) -> Result<Vec<Log>> {
+        let filter = Filter::new()
+            .address(self.vault_manager)
+            .event_signature(VaultManager::MintInitiated::SIGNATURE_HASH)
+            .from_block(from_block);
+
+        let logs = self
+            .provider
+            .get_logs(&filter)
+            .await
+            .context("Failed to query historical MintInitiated events")?;
+
+        Ok(logs)
+    }
+
+    /// Query historical BurnRequested events for this LP vault
+    pub async fn get_historical_burn_events(&self, from_block: u64) -> Result<Vec<Log>> {
+        let filter = Filter::new()
+            .address(self.vault_manager)
+            .event_signature(VaultManager::BurnRequested::SIGNATURE_HASH)
+            .from_block(from_block);
+
+        let logs = self
+            .provider
+            .get_logs(&filter)
+            .await
+            .context("Failed to query historical BurnRequested events")?;
+
+        Ok(logs)
     }
 
     /// Parse a BurnRequested event

--- a/lp-node/src/main.rs
+++ b/lp-node/src/main.rs
@@ -57,6 +57,12 @@ enum Commands {
     },
     /// Show database statistics
     DbStats,
+    /// Scan for pending requests and process them
+    ProcessPending {
+        /// Number of hours to look back (default: 3)
+        #[arg(short, long, default_value_t = 3)]
+        hours: u64,
+    },
 }
 
 #[tokio::main]
@@ -129,6 +135,51 @@ async fn main() -> Result<()> {
         Some(Commands::DbStats) => {
             let cli_handler = cli::LpCli::new(evm);
             cli_handler.db_stats(&db).await?;
+        }
+        Some(Commands::ProcessPending { hours }) => {
+            info!("Scanning for pending requests from the last {} hours", hours);
+            
+            // Initialize Monero client
+            let wallet_rpc_url = env::var("MONERO_WALLET_RPC_URL").ok();
+            let monero = Arc::new(
+                monero::MoneroClient::new_with_wallet_rpc(
+                    config.monero_config.daemon_url.clone(),
+                    config.monero_private_key.clone(),
+                    wallet_rpc_url,
+                )
+                .context("Failed to initialize Monero client")?
+            );
+            
+            // Initialize event listener
+            let lp_vault_bytes: [u8; 20] = config.lp_vault_address.into();
+            let event_listener = Arc::new(events::EventListener::new(
+                db.clone(),
+                evm.clone(),
+                lp_vault_bytes,
+            ));
+            
+            // Initialize swap engine
+            let swap_engine = Arc::new(engine::SwapEngine::new(db.clone(), evm.clone(), monero.clone()));
+            
+            // Calculate from_block based on hours
+            let current_block = evm.get_block_number().await.unwrap_or(0);
+            let blocks_per_hour = 720; // ~5 second blocks on Gnosis
+            let from_block = current_block.saturating_sub(blocks_per_hour * hours);
+            
+            info!("Scanning from block {} to current block {}", from_block, current_block);
+            
+            // Scan historical events
+            event_listener.scan_historical_events(from_block).await?;
+            
+            // Start swap engine to process the tasks
+            swap_engine.start().await?;
+            
+            info!("Processing pending requests...");
+            
+            // Give it some time to process
+            tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+            
+            info!("✅ Pending request scan complete");
         }
         Some(Commands::Start) | None => {
             // Start the LP node server

--- a/lp-node/src/monero.rs
+++ b/lp-node/src/monero.rs
@@ -79,10 +79,16 @@ impl MoneroClient {
             warn!("Wallet RPC not configured - transaction operations will be limited");
         }
 
+        // Create HTTP client with longer timeout for Monero daemon
+        let http_client = Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .context("Failed to create HTTP client")?;
+
         Ok(Self {
             daemon_url,
             wallet_rpc_url,
-            http_client: Arc::new(Client::new()),
+            http_client: Arc::new(http_client),
             private_spend_key,
             private_view_key,
             address,
@@ -133,8 +139,11 @@ impl MoneroClient {
     /// Get current blockchain height from daemon
     pub async fn get_height(&self) -> Result<u64> {
         // Call get_block_count RPC method
+        let url = format!("{}/json_rpc", self.daemon_url);
+        tracing::debug!("Calling Monero daemon at: {}", url);
+        
         let response = self.http_client
-            .post(format!("{}/json_rpc", self.daemon_url))
+            .post(&url)
             .json(&serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": "0",
@@ -142,10 +151,15 @@ impl MoneroClient {
             }))
             .send()
             .await
-            .context("Failed to call Monero daemon")?;
+            .with_context(|| format!("Failed to call Monero daemon at {}", url))?;
+        
+        let status = response.status();
+        tracing::debug!("Monero daemon response status: {}", status);
         
         let result: serde_json::Value = response.json().await
             .context("Failed to parse daemon response")?;
+        
+        tracing::debug!("Monero daemon response: {:?}", result);
         
         let height = result["result"]["count"]
             .as_u64()


### PR DESCRIPTION
Contract changes:
- Add initiateMintWithPriceUpdate() function that combines updatePythPrices + initiateMint
- Refactor initiateMint into internal _initiateMint() for code reuse
- Single transaction eliminates need for two wallet approvals

Frontend changes:
- Update ABI to include new initiateMintWithPriceUpdate function
- Update mintFlow.js to use one-click function
- User now approves once for both Pyth update + mint initiation
- Improved UX: pythFee + griefingDeposit sent in single transaction