### PR TITLE
Fix critical security vulnerabilities from audit

### DIFF
--- a/contracts/VaultManager.sol
+++ b/contracts/VaultManager.sol
@@ -66,6 +66,9 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
     
     wsXMR public immutable wsxmrToken;
     
+    // FIX C-3: Track authorized router for internal balance burns
+    address public liquidityRouter;
+    
     // Pyth oracle
     IPyth public immutable pyth;
     
@@ -76,6 +79,8 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
 
     // Oracle staleness configuration (in seconds)
     uint256 public constant PRICE_MAX_AGE = 2 minutes;
+    // FIX H-2: Tighter staleness for liquidity operations to prevent manipulation
+    uint256 public constant LIQUIDITY_PRICE_MAX_AGE = 30 seconds;
     
     // Buy-and-Burn Strategy State
     uint256 public lastBuyTimestamp; // Last execution timestamp for cooldown enforcement
@@ -89,6 +94,7 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
     uint256 public globalPendingSDAI;
     uint256 public globalPendingETH;
     uint256 public globalBadDebt; // Unbacked wsXMR supply from liquidation shortfalls
+    uint256 public globalPendingBurnDebt; // FIX H-4: Track debt in pending burns separately
     uint256 private _requestNonce;
     mapping(uint24 => bool) public allowedPoolFeeTiers;
     
@@ -261,6 +267,11 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
     event MinBurnAmountUpdated(address indexed lpVault, uint256 newMinBurnAmount);
     event VaultDeactivated(address indexed lpVault);
     event GlobalDebtReconciled(uint256 oldDebt, uint256 newDebt);
+    
+    // FIX L-5: Add missing events for cleanup operations
+    event UserMintRequestsCleanedUp(address indexed user, uint256 removedCount);
+    event UserBurnRequestsCleanedUp(address indexed user, uint256 removedCount);
+    event VaultBurnRequestsCleanedUp(address indexed vault, uint256 removedCount);
     
     // ========== ERRORS ==========
     
@@ -521,11 +532,66 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
     }
     
     /**
+     * @notice FIX M-2: Clean up completed/cancelled mint requests from user tracking array
+     * @param _user Address of the user to clean up
+     */
+    function cleanupUserMintRequests(address _user) external {
+        bytes32[] storage userMints = userMintRequests[_user];
+        uint256 originalLength = userMints.length;
+        uint256 writeIndex = 0;
+        
+        for (uint256 readIndex = 0; readIndex < userMints.length; readIndex++) {
+            MintStatus status = mintRequests[userMints[readIndex]].status;
+            if (status == MintStatus.PENDING || status == MintStatus.READY) {
+                if (writeIndex != readIndex) {
+                    userMints[writeIndex] = userMints[readIndex];
+                }
+                writeIndex++;
+            }
+        }
+        
+        while (userMints.length > writeIndex) {
+            userMints.pop();
+        }
+        
+        emit UserMintRequestsCleanedUp(_user, originalLength - writeIndex);
+    }
+    
+    /**
+     * @notice FIX M-2: Clean up completed/cancelled burn requests from user tracking array
+     * @param _user Address of the user to clean up
+     */
+    function cleanupUserBurnRequests(address _user) external {
+        bytes32[] storage userBurns = userBurnRequests[_user];
+        uint256 originalLength = userBurns.length;
+        uint256 writeIndex = 0;
+        
+        for (uint256 readIndex = 0; readIndex < userBurns.length; readIndex++) {
+            BurnStatus status = burnRequests[userBurns[readIndex]].status;
+            if (status == BurnStatus.REQUESTED || 
+                status == BurnStatus.PROPOSED || 
+                status == BurnStatus.COMMITTED) {
+                if (writeIndex != readIndex) {
+                    userBurns[writeIndex] = userBurns[readIndex];
+                }
+                writeIndex++;
+            }
+        }
+        
+        while (userBurns.length > writeIndex) {
+            userBurns.pop();
+        }
+        
+        emit UserBurnRequestsCleanedUp(_user, originalLength - writeIndex);
+    }
+    
+    /**
      * @notice Clean up completed/cancelled burn requests from vault tracking array
      * @param _lpVault Address of the vault to clean up
      */
     function cleanupVaultBurnRequests(address _lpVault) external {
         bytes32[] storage vaultBurns = vaultBurnRequests[_lpVault];
+        uint256 originalLength = vaultBurns.length;
         uint256 writeIndex = 0;
         
         for (uint256 readIndex = 0; readIndex < vaultBurns.length; readIndex++) {
@@ -543,6 +609,8 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         while (vaultBurns.length > writeIndex) {
             vaultBurns.pop();
         }
+        
+        emit VaultBurnRequestsCleanedUp(_lpVault, originalLength - writeIndex);
     }
     
     /**
@@ -755,13 +823,14 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         Vault storage vault = vaults[request.lpVault];
         if (request.vaultMintNonce != vault.mintNonce) revert InvalidStatus();
         
-        // Verify vault is still healthy enough to support this mint
+        // FIX M-6: Verify vault can support THIS mint, not all pending debt
+        // Checking against all pending debt creates deadlock when other mints are abandoned
         uint256 actualDebt = getActualDebt(vault.normalizedDebt);
-        uint256 totalProjectedDebt = actualDebt + vault.pendingDebt;
+        uint256 projectedDebtWithThisMint = actualDebt + request.wsxmrAmount;
         uint256 availableCollateral = vault.collateralAmount > vault.lockedCollateral
             ? vault.collateralAmount - vault.lockedCollateral
             : 0;
-        uint256 currentRatio = calculateCollateralRatio(availableCollateral, totalProjectedDebt);
+        uint256 currentRatio = calculateCollateralRatio(availableCollateral, projectedDebtWithThisMint);
         if (currentRatio < COLLATERAL_RATIO) revert InsufficientCollateral();
         
         request.status = MintStatus.READY;
@@ -867,15 +936,16 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         // Award griefing deposit based on fault state
         if (depositToTransfer > 0) {
             if (originalStatus == MintStatus.PENDING) {
-                // User failed to lock XMR - compensate LP
-                pendingReturns[vault.lpAddress][address(0)] += depositToTransfer;
-                globalPendingETH += depositToTransfer;
-                emit ReturnQueued(vault.lpAddress, address(0), depositToTransfer);
-            } else {
-                // LP confirmed but timeout expired - return to INITIATOR
+                // FIX H-3: LP failed to respond (never called setMintReady) - return to initiator
+                // The LP should not be rewarded for non-cooperation
                 pendingReturns[request.initiator][address(0)] += depositToTransfer;
                 globalPendingETH += depositToTransfer;
                 emit ReturnQueued(request.initiator, address(0), depositToTransfer);
+            } else {
+                // LP confirmed but user failed to finalize - compensate LP for locking XMR
+                pendingReturns[vault.lpAddress][address(0)] += depositToTransfer;
+                globalPendingETH += depositToTransfer;
+                emit ReturnQueued(vault.lpAddress, address(0), depositToTransfer);
             }
         }
     }
@@ -897,6 +967,48 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         address _lpVault,
         address _user
     ) external nonReentrant returns (bytes32 requestId) {
+        return _requestBurn(_wsxmrAmount, _lpVault, _user, false);
+    }
+    
+    /**
+     * @notice FIX C-3: Allow router to burn wsXMR from internal deposits
+     * @dev Only callable by the wsXMRLiquidityRouter contract
+     * @param _wsxmrAmount Amount of wsXMR to burn from router internal balance
+     * @param _lpVault LP vault to handle the burn
+     * @param _user Address whose internal wsXMR deposit to burn
+     * @return requestId Unique identifier for this burn request
+     */
+    function requestBurnFromRouter(
+        uint256 _wsxmrAmount,
+        address _lpVault,
+        address _user
+    ) external nonReentrant returns (bytes32 requestId) {
+        // Only the authorized router can call this function
+        require(msg.sender == liquidityRouter, "Only router");
+        return _requestBurn(_wsxmrAmount, _lpVault, _user, true);
+    }
+    
+    /**
+     * @notice Set the authorized liquidity router address (one-time setup)
+     * @dev Should be called immediately after router deployment
+     * @param _router Address of the wsXMRLiquidityRouter contract
+     */
+    function setLiquidityRouter(address _router) external {
+        require(liquidityRouter == address(0), "Router already set");
+        require(_router != address(0), "Zero address");
+        liquidityRouter = _router;
+    }
+    
+    /**
+     * @notice Internal burn request logic
+     * @param _fromRouter If true, caller must be router and burn is from internal balance
+     */
+    function _requestBurn(
+        uint256 _wsxmrAmount,
+        address _lpVault,
+        address _user,
+        bool _fromRouter
+    ) internal returns (bytes32 requestId) {
         if (_wsxmrAmount == 0) revert ZeroAmount();
         if (_lpVault == address(0)) revert ZeroAddress();
         if (_user == address(0)) revert ZeroAddress();
@@ -972,9 +1084,15 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         ));
         if (burnRequests[requestId].status != BurnStatus.INVALID) revert BurnAlreadyExists();
         
-        // Only user can initiate burn to prevent malicious relayer attacks
-        require(msg.sender == _user, "Only user can initiate burn");
-        wsxmrToken.burn(_user, _wsxmrAmount);
+        // FIX C-3: Handle both wallet burns and router internal balance burns
+        if (!_fromRouter) {
+            // Standard burn: only user can initiate to prevent malicious relayer attacks
+            require(msg.sender == _user, "Only user can initiate burn");
+            wsxmrToken.burn(_user, _wsxmrAmount);
+        } else {
+            // Router burn: tokens already held by router, will be burned by router
+            // Caller validation already done in requestBurnFromRouter
+        }
         
         // CRITICAL FIX: Physically segregate locked collateral from liquidatable balance
         // Deduct from collateralAmount so liquidators cannot touch user burn escrow
@@ -991,6 +1109,8 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         }
         vault.normalizedDebt -= normalizedBurnAmount;
         globalTotalDebt -= _wsxmrAmount;
+        // FIX H-4: Track this debt as pending to exclude from buy-and-burn
+        globalPendingBurnDebt += _wsxmrAmount;
         
         // Step 1: wsXMR burned, collateral locked (but still liquidatable)
         // LP has BURN_REQUEST_TIMEOUT to lock XMR on Monero and provide secretHash
@@ -1137,8 +1257,9 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
             vault.lockedCollateral = 0; // Protection against liquidation underflows
         }
 
-        // Return base locked collateral to vault
-        vault.collateralAmount += request.lockedCollateral;
+        // CRITICAL FIX H-5: Return unused reward portion to vault to prevent token loss
+        uint256 unusedReward = request.rewardCollateral - safeReward;
+        vault.collateralAmount += request.lockedCollateral + unusedReward;
 
         // Principal tracking for the reward portion
         if (safeReward > 0 && lpPrincipalDeposits[vault.lpAddress] > 0) {
@@ -1155,6 +1276,13 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
             pendingReturns[request.user][GnosisAddresses.SDAI] += safeReward;
             globalPendingSDAI += safeReward;
             emit ReturnQueued(request.user, GnosisAddresses.SDAI, safeReward);
+        }
+        
+        // FIX H-4: Remove from pending burn debt tracking
+        if (globalPendingBurnDebt >= request.wsxmrAmount) {
+            globalPendingBurnDebt -= request.wsxmrAmount;
+        } else {
+            globalPendingBurnDebt = 0;
         }
         
         request.status = BurnStatus.COMPLETED;
@@ -1216,6 +1344,14 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         
         request.lockedCollateral = 0;
         request.rewardCollateral = 0;
+        
+        // FIX H-4: Remove from pending burn debt tracking
+        if (globalPendingBurnDebt >= request.wsxmrAmount) {
+            globalPendingBurnDebt -= request.wsxmrAmount;
+        } else {
+            globalPendingBurnDebt = 0;
+        }
+        
         request.status = BurnStatus.SLASHED;
         
         emit BurnSlashed(_requestId, request.user, totalSeized);
@@ -1234,11 +1370,15 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         
         if (block.timestamp < request.deadline) revert DeadlineNotExpired();
         
-        // Add 15-minute grace period after deadline before permissionless cancellation
-        // Only the user can cancel during the grace period
-        uint256 gracePeriod = 15 minutes;
-        if (block.timestamp < request.deadline + gracePeriod) {
-            require(msg.sender == request.user, "Grace period: only user can cancel");
+        // FIX L-4: Grace period only applies if LP took action (PROPOSED status)
+        // For REQUESTED status (LP never responded), allow immediate permissionless cancellation
+        if (request.status == BurnStatus.PROPOSED) {
+            // Add 15-minute grace period after deadline before permissionless cancellation
+            // Only the user can cancel during the grace period
+            uint256 gracePeriod = 15 minutes;
+            if (block.timestamp < request.deadline + gracePeriod) {
+                require(msg.sender == request.user, "Grace period: only user can cancel");
+            }
         }
         
         _syncVaultYield(request.lpVault);
@@ -1314,8 +1454,18 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         }
         
         // Vault is healthy enough - restore debt and re-mint
-        vault.normalizedDebt += request.normalizedDebtAmount;
+        // CRITICAL FIX C-2: Recompute normalized debt at current index to prevent inflation
+        // The stored normalizedDebtAmount was computed with the old index and may be stale
+        uint256 freshNormalizedAmount = (request.wsxmrAmount * 1e18 + globalDebtIndex - 1) / globalDebtIndex;
+        vault.normalizedDebt += freshNormalizedAmount;
         globalTotalDebt += request.wsxmrAmount;
+        
+        // FIX H-4: Remove from pending burn debt tracking since we're restoring it
+        if (globalPendingBurnDebt >= request.wsxmrAmount) {
+            globalPendingBurnDebt -= request.wsxmrAmount;
+        } else {
+            globalPendingBurnDebt = 0;
+        }
         
         // Return locked collateral to vault's liquid balance
         vault.lockedCollateral -= totalUnlock;
@@ -1376,6 +1526,13 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
                 vault.normalizedDebt += request.normalizedDebtAmount;
                 globalTotalDebt += request.wsxmrAmount;
                 
+                // FIX H-4: Remove from pending burn debt tracking
+                if (globalPendingBurnDebt >= request.wsxmrAmount) {
+                    globalPendingBurnDebt -= request.wsxmrAmount;
+                } else {
+                    globalPendingBurnDebt = 0;
+                }
+                
                 // Release locked collateral back to vault for liquidator to seize
                 uint256 unlockAmount = request.lockedCollateral + request.rewardCollateral;
                 if (vault.lockedCollateral >= unlockAmount) {
@@ -1394,6 +1551,13 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
                 // Their wsXMR was already burned in requestBurn and debt was already reduced
                 // Do NOT re-mint wsXMR or restore debt - that would create unbacked supply
                 // Instead, give them the locked collateral as full compensation
+                
+                // FIX H-4: Remove from pending burn debt tracking (burn is complete, just slashed)
+                if (globalPendingBurnDebt >= request.wsxmrAmount) {
+                    globalPendingBurnDebt -= request.wsxmrAmount;
+                } else {
+                    globalPendingBurnDebt = 0;
+                }
                 
                 uint256 collateralToTransfer = request.lockedCollateral + request.rewardCollateral;
                 if (collateralToTransfer > 0) {
@@ -1526,12 +1690,10 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
             }
         }
         
-        // Only increment liquidation nonce if all burn requests were resolved.
-        // Otherwise, unprocessed burns still reference the current nonce and
-        // must remain valid for future resolution.
-        if (burnBatchEnd >= vaultBurns.length) {
-            vault.liquidationNonce++;
-        }
+        // CRITICAL FIX C-4: Always increment liquidationNonce to invalidate ALL burns atomically
+        // This prevents race conditions where remaining REQUESTED burns can be cancelled
+        // and re-mint wsXMR to an already-liquidated vault
+        vault.liquidationNonce++;
         vault.mintNonce++; // Invalidate all pending mints
         vault.pendingDebt = 0; // Zero pending debt since all mints are now invalid
         
@@ -1550,13 +1712,27 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         Vault storage vault = vaults[_lpAddress];
         if (vault.collateralAmount == 0) return;
         
-        // Yield = current shares held - principal shares deposited
-        // Any shares above principal are yield from sDAI appreciation
+        // CRITICAL FIX H-1: Compare DAI values, not share counts
+        // sDAI is rebasing-by-value: shares stay constant but their DAI value increases
         uint256 principalShares = lpPrincipalShares[_lpAddress];
+        if (principalShares == 0) return; // No principal deposited yet
         
-        if (vault.collateralAmount <= principalShares) return; // No yield
+        // Convert both to DAI values for comparison
+        uint256 currentDaiValue = ISavingsDAI(GnosisAddresses.SDAI).convertToAssets(vault.collateralAmount);
+        uint256 principalDaiValue = ISavingsDAI(GnosisAddresses.SDAI).convertToAssets(principalShares);
         
-        uint256 yieldShares = vault.collateralAmount - principalShares;
+        if (currentDaiValue <= principalDaiValue) return; // No yield
+        
+        uint256 yieldDaiValue = currentDaiValue - principalDaiValue;
+        
+        // Convert yield DAI value back to shares for extraction
+        // Use convertToShares to get exact shares needed for the yield DAI amount
+        uint256 yieldShares = ISavingsDAI(GnosisAddresses.SDAI).convertToShares(yieldDaiValue);
+        
+        // Safety check: don't extract more shares than available
+        if (yieldShares > vault.collateralAmount - principalShares) {
+            yieldShares = vault.collateralAmount - principalShares;
+        }
         
         if (yieldShares <= YIELD_DUST_THRESHOLD) return;
         
@@ -1667,17 +1843,22 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         wsxmrToken.burn(address(this), wsxmrBought);
         
         // 7. Erase LP debt (O(1) calculation)
+        // FIX H-4: Exclude pending burn debt from buy-and-burn calculations
+        // Pending burns have already reduced globalTotalDebt but haven't settled yet
+        uint256 effectiveTotalDebt = globalTotalDebt > globalPendingBurnDebt 
+            ? globalTotalDebt - globalPendingBurnDebt 
+            : 0;
        
         // New index = Old Index * (Remaining Debt / Existing Total Debt)
-        if (globalTotalDebt > 0) {
-            if (wsxmrBought >= globalTotalDebt) {
+        if (effectiveTotalDebt > 0) {
+            if (wsxmrBought >= effectiveTotalDebt) {
                 globalDebtIndex = 1e18; // Reset to standard baseline
                 globalTotalDebt = 0;
             } else {
                 // Single-step calculation prevents cumulative rounding errors
                 uint256 oldIndex = globalDebtIndex;
-                uint256 remainingDebt = globalTotalDebt - wsxmrBought;
-                globalDebtIndex = (oldIndex * remainingDebt) / globalTotalDebt;
+                uint256 remainingDebt = effectiveTotalDebt - wsxmrBought;
+                globalDebtIndex = (oldIndex * remainingDebt) / effectiveTotalDebt;
                 
                 // Recalculate globalTotalDebt to stay consistent with index
                 // This prevents drift from accumulating across multiple buy-and-burn cycles
@@ -1742,9 +1923,52 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
     // ========== PRICE ORACLE FUNCTIONS ==========
     
     /**
+     * @notice Get XMR price in USD (18 decimals) with custom staleness
+     * @param maxAge Maximum age of price in seconds
+     */
+    function getXmrPriceWithAge(uint256 maxAge) public view returns (uint256) {
+        PythStructs.Price memory priceData = pyth.getPriceNoOlderThan(XMR_USD_FEED_ID, maxAge);
+        if (priceData.price <= 0) revert StalePrice();
+        
+        uint256 price = uint256(int256(priceData.price));
+        uint256 conf = uint256(priceData.conf);
+        if (conf * 10 > price) revert StalePrice();
+        
+        int32 expo = priceData.expo;
+        
+        uint256 normalizedPrice;
+        if (expo >= 0) {
+            normalizedPrice = price * (10 ** uint32(expo)) * 1e18;
+        } else {
+            uint32 absExpo = uint32(-expo);
+            if (absExpo >= 18) {
+                normalizedPrice = price / (10 ** (absExpo - 18));
+            } else {
+                normalizedPrice = price * (10 ** (18 - absExpo));
+            }
+        }
+        require(normalizedPrice > 0, "Price normalized to zero");
+        return normalizedPrice;
+    }
+    
+    /**
      * @notice Get XMR price in USD (18 decimals)
      */
     function getXmrPrice() public view returns (uint256) {
+        return getXmrPriceWithAge(PRICE_MAX_AGE);
+    }
+    
+    /**
+     * @notice Get XMR price for liquidity operations (tighter staleness)
+     */
+    function getXmrPriceForLiquidity() public view returns (uint256) {
+        return getXmrPriceWithAge(LIQUIDITY_PRICE_MAX_AGE);
+    }
+    
+    /**
+     * @notice DEPRECATED: Use getXmrPriceWithAge instead
+     */
+    function _getXmrPriceInternal() internal view returns (uint256) {
         PythStructs.Price memory priceData = pyth.getPriceNoOlderThan(XMR_USD_FEED_ID, PRICE_MAX_AGE);
         if (priceData.price <= 0) revert StalePrice();
         
@@ -1775,9 +1999,52 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
     }
     
     /**
+     * @notice Get sDAI price in USD (18 decimals) with custom staleness
+     * @param maxAge Maximum age of price in seconds
+     */
+    function getCollateralPriceWithAge(uint256 maxAge) public view returns (uint256) {
+        PythStructs.Price memory priceData = pyth.getPriceNoOlderThan(SDAI_USD_FEED_ID, maxAge);
+        if (priceData.price <= 0) revert StalePrice();
+        
+        uint256 price = uint256(int256(priceData.price));
+        uint256 conf = uint256(priceData.conf);
+        if (conf * 10 > price) revert StalePrice();
+        
+        int32 expo = priceData.expo;
+        
+        uint256 normalizedPrice;
+        if (expo >= 0) {
+            normalizedPrice = price * (10 ** uint32(expo)) * 1e18;
+        } else {
+            uint32 absExpo = uint32(-expo);
+            if (absExpo >= 18) {
+                normalizedPrice = price / (10 ** (absExpo - 18));
+            } else {
+                normalizedPrice = price * (10 ** (18 - absExpo));
+            }
+        }
+        require(normalizedPrice > 0, "Price normalized to zero");
+        return normalizedPrice;
+    }
+    
+    /**
      * @notice Get sDAI price in USD (18 decimals)
      */
     function getCollateralPrice() public view returns (uint256) {
+        return getCollateralPriceWithAge(PRICE_MAX_AGE);
+    }
+    
+    /**
+     * @notice Get sDAI price for liquidity operations (tighter staleness)
+     */
+    function getCollateralPriceForLiquidity() public view returns (uint256) {
+        return getCollateralPriceWithAge(LIQUIDITY_PRICE_MAX_AGE);
+    }
+    
+    /**
+     * @notice DEPRECATED: Use getCollateralPriceWithAge instead
+     */
+    function _getCollateralPriceInternal() internal view returns (uint256) {
         PythStructs.Price memory priceData = pyth.getPriceNoOlderThan(SDAI_USD_FEED_ID, PRICE_MAX_AGE);
         if (priceData.price <= 0) revert StalePrice();
         
@@ -1875,6 +2142,16 @@ contract VaultManager is Secp256k1, ReentrancyGuard {
         require(vault.normalizedDebt == 0, "Has debt");
         require(vault.pendingDebt == 0, "Has pending debt");
         vault.active = false;
+        
+        // FIX L-6: Reset principal tracking to prevent stale state
+        if (lpPrincipalDeposits[msg.sender] > 0) {
+            globalLpPrincipal -= lpPrincipalDeposits[msg.sender];
+            lpPrincipalDeposits[msg.sender] = 0;
+        }
+        if (lpPrincipalShares[msg.sender] > 0) {
+            globalLpPrincipalShares -= lpPrincipalShares[msg.sender];
+            lpPrincipalShares[msg.sender] = 0;
+        }
         
         // Remove from vaultList to save gas in iterations
         for (uint256 i = 0; i < vaultList.length; i++) {

--- a/contracts/interfaces/IUniswapV3Factory.sol
+++ b/contracts/interfaces/IUniswapV3Factory.sol
@@ -4,4 +4,7 @@ pragma solidity ^0.8.19;
 interface IUniswapV3Factory {
     function getPool(address tokenA, address tokenB, uint24 fee) 
         external view returns (address pool);
+    
+    function createPool(address tokenA, address tokenB, uint24 fee)
+        external returns (address pool);
 }

--- a/contracts/interfaces/IUniswapV3Pool.sol
+++ b/contracts/interfaces/IUniswapV3Pool.sol
@@ -3,4 +3,6 @@ pragma solidity ^0.8.19;
 
 interface IUniswapV3Pool {
     function liquidity() external view returns (uint128);
+    
+    function initialize(uint160 sqrtPriceX96) external;
 }

--- a/contracts/wsXMRLiquidityRouter.sol
+++ b/contracts/wsXMRLiquidityRouter.sol
@@ -148,6 +148,75 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
         // Accept ETH for Pyth fee refunds
     }
 
+    // ========== POOL INITIALIZATION ==========
+    
+    /**
+     * @notice FIX M-7: Initialize the Uniswap V3 pool with oracle-derived price
+     * @dev Must be called before any positions can be created
+     * @param _pythUpdateData Pyth price update data for fresh oracle prices
+     * @return pool Address of the created/initialized pool
+     */
+    function initializePool(bytes[] calldata _pythUpdateData) external payable nonReentrant returns (address pool) {
+        // Update Pyth prices first
+        uint256 pythFee = IPyth(address(vaultManager.pyth())).getUpdateFee(_pythUpdateData);
+        IPyth(address(vaultManager.pyth())).updatePriceFeeds{value: pythFee}(_pythUpdateData);
+        
+        // Refund excess ETH
+        if (msg.value > pythFee) {
+            (bool success, ) = payable(msg.sender).call{value: msg.value - pythFee}("");
+            require(success, "Refund failed");
+        }
+        
+        // Get oracle prices with tight staleness
+        uint256 sDAIPrice = vaultManager.getCollateralPriceForLiquidity();
+        uint256 wsxmrPrice = vaultManager.getXmrPriceForLiquidity();
+        
+        // Calculate sqrtPriceX96 from oracle prices
+        // price = (token1/token0) = (wsxmrPrice/sDAIPrice) if sDAI is token0
+        // sqrtPriceX96 = sqrt(price) * 2^96
+        uint256 priceRatio;
+        if (sDAIIsToken0) {
+            // price = wsxmr/sDAI, need to adjust for decimals
+            // wsxmrPrice is USD per wsXMR (18 decimals), sDAIPrice is USD per sDAI (18 decimals)
+            // price = (wsxmrPrice / sDAIPrice) * (10^18 / 10^8) to account for token decimals
+            priceRatio = (wsxmrPrice * 1e18) / (sDAIPrice * 1e8);
+        } else {
+            // price = sDAI/wsxmr
+            priceRatio = (sDAIPrice * 1e8) / (wsxmrPrice * 1e18);
+        }
+        
+        // Calculate sqrtPriceX96 = sqrt(priceRatio) * 2^96
+        // Use Babylonian method for square root
+        uint256 sqrtPrice = sqrt(priceRatio);
+        uint160 sqrtPriceX96 = uint160((sqrtPrice * (2 ** 96)) / 1e9); // Normalize from 1e18
+        
+        // Create pool if it doesn't exist
+        pool = uniswapFactory.getPool(token0, token1, POOL_FEE);
+        if (pool == address(0)) {
+            pool = uniswapFactory.createPool(token0, token1, POOL_FEE);
+        }
+        
+        // Initialize pool with oracle price
+        IUniswapV3Pool(pool).initialize(sqrtPriceX96);
+        
+        return pool;
+    }
+    
+    /**
+     * @notice Helper function to calculate square root using Babylonian method
+     * @param x Value to calculate square root of
+     * @return y Square root of x
+     */
+    function sqrt(uint256 x) internal pure returns (uint256 y) {
+        if (x == 0) return 0;
+        uint256 z = (x + 1) / 2;
+        y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+    }
+
     // ========== LP FUNCTIONS ==========
     
     /**
@@ -171,7 +240,8 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
     }
     
     /**
-     * @notice LP deallocates sDAI - DEPRECATED, use withdrawSDAI instead
+     * @notice DEPRECATED: Use withdrawSDAI instead
+     * @dev FIX I-5: This function is redundant with withdrawSDAI but kept for backwards compatibility
      * @param _sDAIAmount Amount of sDAI shares to deallocate
      */
     function deallocateLiquidity(uint256 _sDAIAmount) external nonReentrant {
@@ -179,8 +249,6 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
         if (lpLiquidityAllocation[msg.sender] < _sDAIAmount) revert InsufficientBalance();
         
         lpLiquidityAllocation[msg.sender] -= _sDAIAmount;
-        
-        // Transfer sDAI back to LP
         IERC20(GnosisAddresses.SDAI).safeTransfer(msg.sender, _sDAIAmount);
         
         emit LiquidityDeallocated(msg.sender, _sDAIAmount);
@@ -215,6 +283,46 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
         
         emit UserWithdrewWsxmr(msg.sender, _wsxmrAmount);
         emit WsxmrDeallocated(msg.sender, _wsxmrAmount);
+    }
+    
+    /**
+     * @notice FIX C-3: Burn wsXMR from internal deposits to reduce vault debt
+     * @dev Allows LPs who received wsXMR from IL to burn it against their vault
+     * @param _wsxmrAmount Amount of wsXMR to burn from internal balance
+     * @param _lpVault LP vault to handle the burn
+     * @return requestId Unique identifier for this burn request
+     */
+    function burnFromInternalBalance(
+        uint256 _wsxmrAmount,
+        address _lpVault
+    ) external nonReentrant returns (bytes32 requestId) {
+        if (_wsxmrAmount == 0) revert InvalidAmount();
+        if (userWsxmrDeposits[msg.sender] < _wsxmrAmount) revert InsufficientBalance();
+        
+        // Deduct from internal balance
+        userWsxmrDeposits[msg.sender] -= _wsxmrAmount;
+        
+        // Burn the wsXMR tokens
+        wsxmrToken.burn(address(this), _wsxmrAmount);
+        
+        // Request burn through VaultManager (router is authorized caller)
+        requestId = vaultManager.requestBurnFromRouter(_wsxmrAmount, _lpVault, msg.sender);
+        
+        emit WsxmrDeallocated(msg.sender, _wsxmrAmount);
+        
+        return requestId;
+    }
+    
+    /**
+     * @notice FIX I-3: Withdraw accumulated ETH from router contract
+     * @dev ETH can accumulate from Pyth fee refunds
+     */
+    function withdrawETH() external nonReentrant {
+        uint256 balance = address(this).balance;
+        if (balance == 0) revert InvalidAmount();
+        
+        (bool success, ) = payable(msg.sender).call{value: balance}("");
+        require(success, "ETH transfer failed");
     }
 
     // ========== USER FUNCTIONS ==========
@@ -383,9 +491,10 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
             : (_wsxmrAmount, _sDAIAmount);
         
        
+        // FIX H-2: Use tighter staleness window for liquidity operations
         // This prevents MEV arbitrage via flash loan pool manipulation
-        uint256 sDAIPrice = vaultManager.getCollateralPrice();
-        uint256 wsxmrPrice = vaultManager.getXmrPrice();
+        uint256 sDAIPrice = vaultManager.getCollateralPriceForLiquidity();
+        uint256 wsxmrPrice = vaultManager.getXmrPriceForLiquidity();
         
         // Calculate expected ratio based on oracle prices
         // sDAI amount * sDAI price should approximately equal wsXMR amount * wsXMR price
@@ -515,9 +624,9 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
             "Position too young to close"
         );
         
-        // Calculate oracle-based minimum outputs for MEV protection
-        uint256 currentSDAIPrice = vaultManager.getCollateralPrice();
-        uint256 currentXmrPrice = vaultManager.getXmrPrice();
+        // FIX H-2: Calculate oracle-based minimum outputs with tight staleness for MEV protection
+        uint256 currentSDAIPrice = vaultManager.getCollateralPriceForLiquidity();
+        uint256 currentXmrPrice = vaultManager.getXmrPriceForLiquidity();
         
         // Determine token order
         (, , , , , , , uint128 liquidity, , , , ) = 
@@ -576,9 +685,11 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
             + (wsxmrPrincipal * currentXmrPrice) / 1e8;
         uint256 expectedValueUSD = position.lpInitialValueUSD + position.userInitialValueUSD;
         
-        // 80% floor as safety net for extreme IL scenarios
+        // FIX M-1: 50% floor to accommodate extreme but legitimate IL scenarios
+        // Full-range positions can experience >20% IL during significant price movements
+        // A 90% price drop results in ~42% IL, so 50% floor is more appropriate
         require(
-            withdrawnValueUSD >= (expectedValueUSD * 80) / 100,
+            withdrawnValueUSD >= (expectedValueUSD * 50) / 100,
             "Withdrawal value too low - possible manipulation"
         );
         
@@ -696,26 +807,11 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
         
         if (collected0 == 0 && collected1 == 0) return;
 
-        // Sanity check: fees should not exceed a reasonable percentage of
-        // the position's original value. Cap at 100% of original deposit
-        // to prevent manipulation via pool state attacks.
-        uint256 maxReasonableFee0;
-        uint256 maxReasonableFee1;
-        if (sDAIIsToken0) {
-            maxReasonableFee0 = position.sDAIAmount;
-            maxReasonableFee1 = position.wsxmrAmount;
-        } else {
-            maxReasonableFee0 = position.wsxmrAmount;
-            maxReasonableFee1 = position.sDAIAmount;
-        }
-
-        // Cap collected amounts to prevent manipulation
-        if (collected0 > maxReasonableFee0) {
-            collected0 = maxReasonableFee0;
-        }
-        if (collected1 > maxReasonableFee1) {
-            collected1 = maxReasonableFee1;
-        }
+        // CRITICAL FIX C-1 & M-3: Remove arbitrary fee cap
+        // Uniswap V3 fees are legitimate by definition and can legitimately exceed
+        // 100% of original deposit for high-volume pools or long-lived positions.
+        // Capping causes permanent token loss since tokens are already transferred.
+        // The oracle validation in createPosition already prevents manipulation.
         
         // Determine token mapping using immutable sDAIIsToken0
         uint256 sDAIFees = sDAIIsToken0 ? collected0 : collected1;
@@ -922,14 +1018,38 @@ contract wsXMRLiquidityRouter is ReentrancyGuard, IERC721Receiver {
     /**
      * @notice Handle receipt of NFT positions from Uniswap V3
      * @dev Required to receive ERC721 tokens (Uniswap V3 positions)
+     * @dev FIX L-1: Validates sender to prevent arbitrary NFT lockup
      */
     function onERC721Received(
         address,
-        address,
-        uint256,
+        address /* from */,
+        uint256 tokenId,
         bytes calldata
     ) external override returns (bytes4) {
         require(msg.sender == address(positionManager), "Only Uniswap V3 NFTs");
+        
+        // FIX L-1: Verify the NFT is for our pool to prevent arbitrary NFT deposits
+        // This prevents users from accidentally or maliciously locking random NFTs
+        (
+            ,
+            ,
+            address nftToken0,
+            address nftToken1,
+            uint24 nftFee,
+            ,
+            ,
+            ,
+            ,
+            ,
+            ,
+        ) = positionManager.positions(tokenId);
+        
+        require(
+            (nftToken0 == token0 && nftToken1 == token1 && nftFee == POOL_FEE) ||
+            (nftToken0 == token1 && nftToken1 == token0 && nftFee == POOL_FEE),
+            "NFT not for this pool"
+        );
+        
         return IERC721Receiver.onERC721Received.selector;
     }
 }


### PR DESCRIPTION
Critical Fixes:
- C-1/M-3: Remove collectFees token loss from arbitrary cap
- C-2: Recompute normalizedDebtAmount at cancelBurn to prevent inflation
- C-3: Add burnFromInternalBalance() to enable IL wsXMR burning
- C-4: Always increment liquidationNonce to invalidate all burns atomically

High Severity Fixes:
- H-1: Fix yield extraction to compare DAI values via convertToAssets()
- H-2: Add 30-second staleness window for liquidity operations
- H-3: Return griefing deposit to initiator on LP timeout
- H-4: Track globalPendingBurnDebt separately from buy-and-burn
- H-5: Return unused reward portion to vault in finalizeBurn

Medium Severity Fixes:
- M-1: Lower IL floor from 80% to 50% for extreme price movements
- M-2: Add cleanup functions for mint/burn request arrays
- M-6: Check only current request health in setMintReady
- M-7: Add initializePool() with oracle-derived price

Low Severity Fixes:
- L-1: Validate NFT is for correct pool in onERC721Received
- L-4: Remove grace period for REQUESTED status burns
- L-5: Add events for cleanup operations
- L-6: Reset principal tracking on vault deactivation

Informational Fixes:
- I-3: Add withdrawETH() for accumulated fees
- I-5: Mark deallocateLiquidity as deprecated